### PR TITLE
Factor out bintray credentials to a setting key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 An sbt interface for publishing and resolving [bintray](https://bintray.com) packages.
 
-## install
+## Install
 
-### what you need
+### What you need
 
 - an account on [bintray](https://bintray.com) (get one [here](https://bintray.com/signup/index))
 - a desire to build a more diverse Scala library ecosystem
@@ -25,7 +25,7 @@ Be sure to use the [latest launcher](http://www.scala-sbt.org/download.html)
 
 ## Resolving bintray artifacts
 
-Using sbt 0.13.6+, you don't need this plugin to resolve bintray-hosted dependencies.
+Add the following to your build file:
 
 ```scala
 resolvers += Resolver.jcenterRepo
@@ -49,18 +49,20 @@ resolvers += Resolver.bintrayRepo("otherUser", "maven")
 
 ### Publishing
 
-To publish a package to bintray, you need a bintray account. You can do so [here](https://bintray.com/signup/index). 
+To publish a package to bintray, you need a bintray account. You can create one [here](https://bintray.com/signup/index).
 `BintrayPlugin` is an auto plugin that will be added to all projects in your build.
 This plugin will upload and release your artifacts into bintray when you run `publish`.
 
 If you try to publish at this point, you will be prompted for your bintray username and api key. This will generate an sbt credentials
 file under `~/.bintray/.credentials` used to authenticate publishing requests to bintray.
 
-You can interactively change to bintray credentials used by sbt anytime with
+You can interactively change bintray credentials stored in the credentials file with
 
     > bintrayChangeCredentials
 
-Note you will need to reload your project afterwards which will reset your `publishTo` setting.
+Note that you will need to reload your project afterwards which will reset your `publishTo` setting.
+
+You may provide bintray credentials via environment variables (`BINTRAY_USER` and `BINTRAY_PASS`) or via system properties (`-Dbintray.user=...` and `-Dbintray.pass=...`) as well.
 
 At any time you can check who you will be authenticated as with the `bintrayWhoami` setting which will print your bintray username
 
@@ -111,7 +113,7 @@ bintrayPackageLabels := Seq("hipster", "keen")
 
 #### Metadata
 
-In addition to labels, you can also assign metadata attributes that expose information to package tooling. These can be assigned at the package and the version levels. By default, this plugin assigns a flag indicating "this is an sbt plugin" to the package and the scala version and optionally sbt version to the package version. You can assign these with the `packageAttributes in bintray` and `versionAttributes in bintray` setting keys. These values must be typed and conform to the [types](https://github.com/softprops/bintry#metadata) bintray [exposes](https://bintray.com/docs/api/#_attributes).
+In addition to labels, you can also assign metadata attributes that expose information to package tooling. These can be assigned at the package and the version levels. By default, this plugin assigns a flag indicating "this is an sbt plugin" to the package and the scala version and optionally sbt version to the package version. You can assign these with the `bintrayPackageAttributes` and `bintrayVersionAttributes` setting keys. These values must be typed and conform to the [types](https://github.com/softprops/bintry#metadata) bintray [exposes](https://bintray.com/docs/api/#_attributes).
 
 ```scala
 // append custom package attributes

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 organization := "me.lessis"
 name := "bintray-sbt"
-version := "0.3.0"
 description := "package publisher for bintray.com"
 homepage := Some(url(s"https://github.com/softprops/${name.value}#readme"))
 sbtPlugin := true
@@ -29,3 +28,6 @@ lsSettings
 externalResolvers in LsKeys.lsync := (resolvers in bintray).value
 bintrayRepository := "sbt-plugin-releases"
 bintrayOrganization := Some("sbt")
+
+enablePlugins(GitVersioning)
+git.useGitDescribe := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,3 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-        Resolver.ivyStylePatterns)
-
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0-SNAPSHOT")
-
-resolvers += Resolver.sonatypeRepo("snapshots")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")

--- a/src/main/scala/BintrayKeys.scala
+++ b/src/main/scala/BintrayKeys.scala
@@ -32,6 +32,9 @@ trait BintrayKeys {
   val bintrayCredentialsFile = settingKey[File](
     "File containing bintray api credentials")
 
+  val bintrayCredentials = settingKey[Option[BintrayCredentials]](
+    "Bintray api credentials")
+
   val bintrayPackageVersions = taskKey[Seq[String]](
     "List bintray versions for the current package")
 


### PR DESCRIPTION
Also allow to provide bintray credentials via environment variable or system property. Resolves #25.

This PR also adds `sbt-git` plugin, which allows automatic version management depending on the latest tag in git. In addition to clean version management this is also a one step forward to tag based releases (only step required for a release is to create a tag on some commit).
