### PR TITLE
(Don't merge) Porting to sbt 1.0.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ pomExtra := (
     </developer>
   </developers>
 )
-lsSettings
-externalResolvers in LsKeys.lsync := (resolvers in bintray).value
-bintrayRepository := "sbt-plugin-releases"
-bintrayOrganization := Some("sbt")
+// lsSettings
+// externalResolvers in LsKeys.lsync := (resolvers in bintray).value
+// bintrayRepository := "sbt-plugin-releases"
+// bintrayOrganization := Some("sbt")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.0.0-M4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-        Resolver.ivyStylePatterns)
+// resolvers += Resolver.url(
+//   "bintray-sbt-plugin-releases",
+//     url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+//         Resolver.ivyStylePatterns)
 
-addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
+// addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0-SNAPSHOT")
+// addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0-SNAPSHOT")
 
-resolvers += Resolver.sonatypeRepo("snapshots")
+// resolvers += Resolver.sonatypeRepo("snapshots")

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -122,7 +122,7 @@ object Bintray {
   def resolveVcsUrl: Try[Option[String]] =
     Try {
       val pushes =
-        sbt.Process("git" :: "remote" :: "-v" :: Nil).!!.split("\n")
+        sys.process.Process("git" :: "remote" :: "-v" :: Nil).!!.split("\n")
          .map {
            _.split("""\s+""") match {
              case Array(name, url, "(push)") =>

--- a/src/main/scala/BintrayKeys.scala
+++ b/src/main/scala/BintrayKeys.scala
@@ -1,6 +1,6 @@
 package bintray
 
-import sbt._
+import sbt._, Keys._, syntax._
 
 trait BintrayKeys {
   val bintray = taskKey[String]("bintray-sbt is an interface for the bintray package service")

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -4,8 +4,7 @@ import bintry.Attr
 import sbt.{ AutoPlugin, Credentials, Global, Path, Resolver, Setting, Task, Tags, ThisBuild }
 import sbt.Classpaths.publishTask
 import sbt.Def.{ Initialize, setting, task, taskDyn }
-import sbt.Keys._
-import sbt.Path.richFile
+import sbt._, Keys._, syntax._
 
 object BintrayPlugin extends AutoPlugin {
   import BintrayKeys._


### PR DESCRIPTION
Here's sbt 1.0.0-M4 port of bintray-sbt. So this like literally a request to pull into some branch, but not merge.
### side note

If someone wants to use this as source dependency, here's how to do it:

```
lazy val bintraySbt = RootProject(uri("git://github.com/eed3si9n/bintray-sbt#topic/sbt1.0.0-M4"))
lazy val root = (project in file(".")).
  dependsOn(bintraySbt)
```
