### PR TITLE
Pass pgp credentials via other mechanisms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: scala
 sudo: false
 script: sbt test
+jdk: oraclejdk8


### PR DESCRIPTION
Previously, pgp passphrases could not be provided from system properties
and environment variables. This commit enables this use case and makes
pgp credentials behave in the same way as sonatype credentials do.