### PR TITLE
Downgrading dependency to solve issue with json4s-core dependency version conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk8
 
 env:
   matrix:
-    - SBT_CMD="test"
-    - SBT_CMD="++2.12.2 ^^1.0.0-M6 test"
+    - SBT_CMD="test publishLocal scripted"
+    - SBT_CMD="++2.12.2 ^^1.0.0-M6 test publishLocal scripted"
 
 script: sbt "$SBT_CMD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk8
 
 env:
   matrix:
-    - SBT_CMD="test publishLocal scripted"
-    - SBT_CMD="++2.12.2 ^^1.0.0-M6 test publishLocal scripted"
+    - SBT_CMD=";test;publishLocal;scripted"
+    - SBT_CMD=";++2.12.2;^^1.0.0-M6;test;publishLocal;scripted"
 
 script: sbt "$SBT_CMD"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val unusedWarnings = Seq("-Ywarn-unused-import", "-Ywarn-unused")
 
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-    version in ThisBuild := "0.4.0",
+    version in ThisBuild := "0.5.0",
     organization in ThisBuild := "org.foundweekends",
     homepage in ThisBuild := Some(url(s"https://github.com/sbt/${name.value}/#readme")),
     licenses in ThisBuild := Seq("MIT" ->
@@ -31,7 +31,7 @@ lazy val root = (project in file("."))
     name := "sbt-bintray",
     sbtPlugin := true,
     libraryDependencies ++= Seq(
-      "org.foundweekends" %% "bintry" % "0.5.0",
+      "org.foundweekends" %% "bintry" % "0.6.0",
       "org.slf4j" % "slf4j-nop" % "1.7.7"), // https://github.com/softprops/bintray-sbt/issues/26
     resolvers += Resolver.sonatypeRepo("releases")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,22 @@ lazy val root = (project in file("."))
   .settings(
     name := "sbt-bintray",
     sbtPlugin := true,
+    crossSbtVersions := List("0.13.15", "1.0.0-M6"),
+    scalaVersion := (sbtVersionSeries.value match {
+      case Sbt013 => "2.10.6"
+      case Sbt1 => "2.12.2"
+    }),
     libraryDependencies ++= Seq(
       "org.foundweekends" %% "bintry" % "0.6.0",
       "org.slf4j" % "slf4j-nop" % "1.7.7"), // https://github.com/softprops/bintray-sbt/issues/26
-    resolvers += Resolver.sonatypeRepo("releases")
+    resolvers += Resolver.sonatypeRepo("releases"),
+    ScriptedPlugin.scriptedSettings,
+    scriptedBufferLog := false,
+    scriptedLaunchOpts := {
+      scriptedLaunchOpts.value ++
+        Seq("-Xmx1024M",
+          "-Dplugin.version=" + version.value,
+          "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")
+    },
+    scripted := crossScripted.evaluated
   )

--- a/project/CrossBuildingPlugin.scala
+++ b/project/CrossBuildingPlugin.scala
@@ -1,0 +1,88 @@
+import sbt.{Def, _}
+import Keys._
+
+sealed trait SbtVersionSeries
+case object Sbt013 extends SbtVersionSeries
+case object Sbt1 extends SbtVersionSeries
+
+object CrossBuildingPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  object autoImport {
+    val sbtPartV = settingKey[Option[(Int, Int)]]("")
+    val sbtVersionSeries = settingKey[SbtVersionSeries]("")
+    val crossScripted = inputKey[Unit]("")
+  }
+
+  import autoImport._
+  override def globalSettings = Seq(
+    sbtPartV := CrossVersion partialVersion (sbtVersion in pluginCrossBuild).value,
+    sbtVersionSeries := (sbtPartV.value match {
+      case Some((0, 13)) => Sbt013
+      case Some((1, _)) => Sbt1
+      case _ =>
+        sys error s"Unhandled sbt version ${(sbtVersion in pluginCrossBuild).value}"
+    })
+  )
+
+  import sbt.{Def, File, ScriptedPlugin, complete}
+  import sbt.ScriptedPlugin._
+
+  override def projectSettings = Seq(
+    // See https://github.com/sbt/sbt/issues/3245
+    crossScripted := Def.inputTask {
+      val _: Unit = scriptedDependencies.value
+      val scriptedTests = ScriptedPlugin.scriptedTests.value
+      val testDir = sbtTestDirectory.value
+      val enabledBuffer = scriptedBufferLog.value
+      val launcher = sbtLauncher.value
+      val launchOpts = scriptedLaunchOpts.value.toArray
+      val args = {
+        // It has to be chained to prevent illegal dynamic reference...
+        ScriptedPlugin
+          .asInstanceOf[{
+            def scriptedParser(f: File): complete.Parser[Seq[String]]
+          }]
+          .scriptedParser(sbtTestDirectory.value)
+          .parsed
+          .toArray
+      }
+      try {
+        if (sbtVersionSeries.value == Sbt1) {
+          scriptedTests
+            .asInstanceOf[{
+              def run(
+                  x1: File,
+                  x2: Boolean,
+                  x3: Array[String],
+                  x4: File,
+                  x5: Array[String],
+                  x6: java.util.List[File]
+              ): Unit
+            }]
+            .run(testDir,
+                 enabledBuffer,
+                 args,
+                 launcher,
+                 launchOpts,
+                 new java.util.ArrayList())
+        } else {
+          scriptedTests
+            .asInstanceOf[{
+              def run(
+                  x1: File,
+                  x2: Boolean,
+                  x3: Array[String],
+                  x4: File,
+                  x5: Array[String]
+              ): Unit
+            }]
+            .run(testDir, enabledBuffer, args, launcher, launchOpts)
+        }
+      } catch {
+        case e: java.lang.reflect.InvocationTargetException => throw e.getCause
+      }
+    }.evaluated
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,5 @@ resolvers += Resolver.url(
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 resolvers += Resolver.sonatypeRepo("snapshots")
+
+libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,7 @@ resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",
     url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
-
-// addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
 resolvers += Resolver.sonatypeRepo("snapshots")
 
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,0 +1,7 @@
+ScriptedPlugin.scriptedSettings
+
+scriptedLaunchOpts := { scriptedLaunchOpts.value ++
+  Seq("-Xmx1024M", "-Dplugin.version=" + version.value, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")
+}
+
+scriptedBufferLog := false

--- a/scripted.sbt
+++ b/scripted.sbt
@@ -1,7 +1,0 @@
-ScriptedPlugin.scriptedSettings
-
-scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-  Seq("-Xmx1024M", "-Dplugin.version=" + version.value, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005")
-}
-
-scriptedBufferLog := false

--- a/src/main/scala/BintrayKeys.scala
+++ b/src/main/scala/BintrayKeys.scala
@@ -65,6 +65,9 @@ trait BintrayKeys {
   val bintrayVcsUrl = taskKey[Option[String]](
     "Canonical url for hosted version control repository")
 
+  val __bintrayErrorRepro = taskKey[String](
+    "Recreates the issue #104")
+
   /** named used for common package attributes lifted from sbt
    *  build definitions */
   object AttrNames {

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -1,9 +1,10 @@
 package bintray
 
 import bintry.Attr
-import sbt.{ AutoPlugin, Credentials, Global, Path, Resolver, Setting, Task, Tags, ThisBuild }
+import org.json4s.native.JsonMethods
+import sbt.{AutoPlugin, Credentials, Global, Path, Resolver, Setting, Tags, Task, ThisBuild}
 import sbt.Classpaths.publishTask
-import sbt.Def.{ Initialize, setting, task, taskDyn }
+import sbt.Def.{Initialize, setting, task, taskDyn}
 import sbt.Keys._
 import sbt._
 
@@ -116,6 +117,24 @@ object BintrayPlugin extends AutoPlugin {
       val _ = publishVersionAttributesTask.value
       val repo = bintrayRepo.value
       repo.release(bintrayPackage.value, version.value, sLog.value)
+    },
+
+    /*
+     * Reproduces issue: https://github.com/sbt/sbt-bintray/issues/104
+     */
+    __bintrayErrorRepro := {
+      import org.json4s.JsonDSL._
+
+      val jsonMethods = new JsonMethods {}
+      jsonMethods.compact(
+        jsonMethods.render(
+          ("name"     -> "randomName") ~
+            ("desc"     -> Option("basicDescription")) ~
+            ("licenses" -> List("Apache", "MIT")) ~
+            ("labels"   -> List("label1", "label2")) ~
+            ("vcs_url"  -> Option("vcs"))
+        )
+      )
     }
   ) ++ Seq(
     resolvers ++= (resolvers in bintray).value,

--- a/src/sbt-test/sbt-bintray/jsonErrorTest/build.sbt
+++ b/src/sbt-test/sbt-bintray/jsonErrorTest/build.sbt
@@ -1,0 +1,17 @@
+enablePlugins(BintrayPlugin)
+
+
+val testJsonSerialization = inputKey[Unit]("testJsonSerialization")
+
+testJsonSerialization := {
+  val expected =
+    "{" +
+      """"name":"randomName",""" +
+      """"desc":"basicDescription",""" +
+      """"licenses":["Apache","MIT"],""" +
+      """"labels":["label1","label2"],""" +
+      """"vcs_url":"vcs"""" +
+    "}"
+  val found: String = __bintrayErrorRepro.value
+  assert(expected == found, s"Expected: $expected but found: $found")
+}

--- a/src/sbt-test/sbt-bintray/jsonErrorTest/project/plugins.sbt
+++ b/src/sbt-test/sbt-bintray/jsonErrorTest/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.foundweekends" % "sbt-bintray" % pluginVersion)
+}

--- a/src/sbt-test/sbt-bintray/jsonErrorTest/test
+++ b/src/sbt-test/sbt-bintray/jsonErrorTest/test
@@ -1,0 +1,1 @@
+> testJsonSerialization


### PR DESCRIPTION
Issue described here: https://github.com/sbt/sbt-bintray/issues/104

Before this can be built successfully we need to have first this guy merged: https://github.com/sbt/bintry/pull/28

It fully reproduces the issue (take a look - just change back `"org.foundweekends" %% "bintry" % "0.6.0"`  to `"org.foundweekends" %% "bintry" % "0.5.0"` ).

I do however has one critical problem with running `sbt-scripted` with `sbt 1.0.0-M5` (look at comment on PR)