### PR TITLE
Fix use of settings logger in task scope

### DIFF
--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -139,7 +139,7 @@ object BintrayPlugin extends AutoPlugin {
 
   private def warnToRelease: Initialize[Task[Unit]] =
     task {
-      val log = sLog.value
+      val log = streams.value.log
       log.warn("You must run bintrayRelease once all artifacts are staged.")
     }
 
@@ -189,7 +189,7 @@ object BintrayPlugin extends AutoPlugin {
       val btyOrg = bintrayOrganization.value
       val repoName = bintrayRepository.value
       (Bintray.withRepo(credsFile, btyOrg, repoName) { repo =>
-        repo.packageVersions(bintrayPackage.value, sLog.value)
+        repo.packageVersions(bintrayPackage.value, streams.value.log)
       }).getOrElse(Nil)
     }
 }


### PR DESCRIPTION
Addresses issue #85.

In task scope, use `streams.value.log` instead of `sLog`.  Thanks to @dwijnand for the pointer on how to fix this.

Note that I've also added `.idea` to the `.gitignore` file as part of this.  If you want I can remove that change, but it was useful to me and presumably would be to anyone else who uses IntelliJ as their IDE for Scala projects, which is why I left it in there for now.

There aren't any automated tests for this project at the moment; I didn't think it feasible to introduce them in the scope of this change.  However, I have manually tested by locally publishing an updated copy of this plugin and verifying that the behaviour is fixed.