### PR TITLE
No more questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,36 @@ To publish a package to bintray, you need a bintray account. You can register fo
 `BintrayPlugin` is an auto plugin that will be added to all projects in your build.
 This plugin will upload and release your artifacts into bintray when you run `publish`.
 
-If you try to publish at this point, you will be prompted for your bintray username and api key. This will generate an sbt credentials
-file under `~/.bintray/.credentials` used to authenticate publishing requests to bintray.
-
-You can interactively change to bintray credentials used by sbt anytime with
-
-    > bintrayChangeCredentials
-
-Note you will need to reload your project afterwards which will reset your `publishTo` setting.
-
 At any time you can check who you will be authenticated as with the `bintrayWhoami` setting which will print your bintray username
 
     > bintrayWhoami
+
+#### Credentials
+
+To publish, you need to provide Bintray credentials (user name and API key). There are three ways to set them up: credential file, properties, and environment variables.
+
+1. Credentials file
+
+sbt-bintray will look for a credentials file under `~/.bintray/.credentials` used to authenticate publishing requests to bintray.
+
+You can interactively set up or change the bintray credentials used by sbt anytime with
+
+    > bintrayChangeCredentials
+
+Note you will need to `reload` your project afterwards which will reset your `publishTo` setting.
+
+
+2.  Properties
+
+You can pass the user and pass as JVM properties when starting sbt:
+
+    sbt -Dbintray.user=yourBintrayUser -Dbintray.pass=yourBintrayPass
+    
+3. Environment variables
+
+sbt-bintray will look for bintray user and pass in the environment variables `BINTRAY_USER` and  `BINTRAY_PASS`.
+
+#### Bintray organization
 
 You may optionally wish to publish to a [bintray organization](https://bintray.com/docs/usermanual/interacting/interacting_bintrayorganizations.html)
 instead of your individual bintray user account. To do so, use the `bintrayOrganization` setting in your project's build definition.
@@ -86,7 +104,7 @@ organization is named `maven`.  If your Maven repository is named differently, y
 bintrayRepository := "oss-maven"
 ```
 
-##### Staging (optional)
+#### Staging (optional)
 
 If you want to stage your all artifacts first, put this in your settings:
 

--- a/notes/0.5.0.markdown
+++ b/notes/0.5.0.markdown
@@ -1,0 +1,3 @@
+## changes
+
+* support loading bintray credentials from properties or environment

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -124,14 +124,15 @@ object Bintray {
     Try {
       val pushes =
         sys.process.Process("git" :: "remote" :: "-v" :: Nil).!!.split("\n")
-         .map {
+         .flatMap {
            _.split("""\s+""") match {
              case Array(name, url, "(push)") =>
                Some((name, url))
              case e =>
                None
            }
-         }.flatten
+         }
+
       pushes
         .find { case (name, _) => "origin" == name }
         .orElse(pushes.headOption)

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -53,20 +53,16 @@ object Bintray {
     repoCache.getOrElseUpdate((credential, org, repoName), BintrayRepo(credential, org, repoName))
 
   private[bintray] def ensuredCredentials(
-    credsFile: File, prompt: Boolean = true): Option[BintrayCredentials] =
-      propsCredentials("bintray")
-        .orElse(envCredentials("bintray"))
-        .orElse(BintrayCredentials.read(credsFile)) match {
-          case None =>
-            if (prompt) {
-              println("bintray-sbt requires your bintray credentials.")
-              saveBintrayCredentials(credsFile)(requestCredentials())
-              ensuredCredentials(credsFile, prompt)
-            } else {
-              println(s"Missing bintray credentials $credsFile. Some bintray features depend on this.")
-              None
-            }
-          case creds => creds
+    credsFile: File, log: Logger): Option[BintrayCredentials] =
+      propsCredentials
+        .orElse(envCredentials)
+        .orElse(BintrayCredentials.read(credsFile))
+        .orElse {
+          log.error(s"Missing bintray credentials. " +
+            s"Either create a credentials file with the bintrayChangeCredentials task, " +
+            s"set the BINTRAY_USER and BINTRAY_PASS environment variables or " +
+            s"pass bintray.user and bintray.pass properties to sbt.")
+          None
         }
 
   private def propsCredentials =

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -79,7 +79,7 @@ object Bintray {
 
   /** assign credentials or ask for new ones */
   private[bintray] def changeCredentials(credsFile: File, log: Logger): Unit =
-    Bintray.ensuredCredentials(credsFile, log) match {
+    Bintray.ensuredCredentials(credsFile, Logger.Null) match {
       case None =>
         saveBintrayCredentials(credsFile)(requestCredentials(), log)
       case Some(BintrayCredentials(user, pass)) =>

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -41,9 +41,9 @@ object Bintray {
       }
     }
 
-  def withRepo[A](credsFile: File, org: Option[String], repoName: String, prompt: Boolean = true)
+  def withRepo[A](credsFile: File, org: Option[String], repoName: String, log: Logger)
     (f: BintrayRepo => A): Option[A] =
-    ensuredCredentials(credsFile, prompt) map { cred =>
+    ensuredCredentials(credsFile, log) map { cred =>
       val repo = cachedRepo(cred, org, repoName)
       f(repo)
     }
@@ -78,12 +78,12 @@ object Bintray {
     } yield BintrayCredentials(name, pass)
 
   /** assign credentials or ask for new ones */
-  private[bintray] def changeCredentials(credsFile: File): Unit =
-    Bintray.ensuredCredentials(credsFile) match {
+  private[bintray] def changeCredentials(credsFile: File, log: Logger): Unit =
+    Bintray.ensuredCredentials(credsFile, log) match {
       case None =>
-        saveBintrayCredentials(credsFile)(requestCredentials())
+        saveBintrayCredentials(credsFile)(requestCredentials(), log)
       case Some(BintrayCredentials(user, pass)) =>
-        saveBintrayCredentials(credsFile)(requestCredentials(Some(user), Some(pass)))
+        saveBintrayCredentials(credsFile)(requestCredentials(Some(user), Some(pass)), log)
     }
 
   private[bintray] def buildResolvers(creds: Option[BintrayCredentials], org: Option[String], repoName: String): Seq[Resolver] =
@@ -91,23 +91,21 @@ object Bintray {
       case BintrayCredentials(user, _) => Seq(Resolver.bintrayRepo(org.getOrElse(user), repoName))
     } getOrElse Nil
 
-  private def saveBintrayCredentials(to: File)(creds: (String, String)) = {
-    println(s"saving credentials to $to")
+  private def saveBintrayCredentials(to: File)(creds: (String, String), log: Logger) = {
+    log.info(s"saving credentials to $to")
     val (name, pass) = creds
     BintrayCredentials.writeBintray(name, pass, to)
-    println("reload project for sbt setting `publishTo` to take effect")
+    log.info("reload project for sbt setting `publishTo` to take effect")
   }
 
   // todo: generalize this for both bintray & sonatype credential prompts
   private def requestCredentials(
     defaultName: Option[String] = None,
     defaultKey: Option[String] = None): (String, String) = {
-    val name = Prompt("Enter bintray username%s" format(
-      defaultName.map(" (%s)".format(_)).getOrElse(""))).orElse(defaultName).getOrElse {
+    val name = Prompt("Enter bintray username%s" format defaultName.map(" (%s)".format(_)).getOrElse("")).orElse(defaultName).getOrElse {
       sys.error("bintray username required")
     }
-    val pass = Prompt.descretely("Enter bintray API key %s" format(
-      defaultKey.map(_ => "(use current)").getOrElse("(under https://bintray.com/profile/edit)")))
+    val pass = Prompt.descretely("Enter bintray API key %s" format defaultKey.map(_ => "(use current)").getOrElse("(under https://bintray.com/profile/edit)"))
         .orElse(defaultKey).getOrElse {
           sys.error("bintray API key required")
         }

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -58,7 +58,7 @@ object Bintray {
         .orElse(envCredentials)
         .orElse(BintrayCredentials.read(credsFile))
         .orElse {
-          log.error(s"Missing bintray credentials. " +
+          log.warn(s"Missing bintray credentials. " +
             s"Either create a credentials file with the bintrayChangeCredentials task, " +
             s"set the BINTRAY_USER and BINTRAY_PASS environment variables or " +
             s"pass bintray.user and bintray.pass properties to sbt.")

--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -69,16 +69,16 @@ object Bintray {
           case creds => creds
         }
 
-  private def propsCredentials(key: String) =
+  private def propsCredentials =
     for {
-      name <- sys.props.get(s"$key.user")
-      pass <- sys.props.get(s"$key.pass")
+      name <- sys.props.get("bintray.user")
+      pass <- sys.props.get("bintray.pass")
     } yield BintrayCredentials(name, pass)
 
-  private def envCredentials(key: String) =
+  private def envCredentials =
     for {
-      name <- sys.env.get(s"${key.toUpperCase}_USER")
-      pass <- sys.env.get(s"${key.toUpperCase}_PASS")
+      name <- sys.env.get("BINTRAY_USER")
+      pass <- sys.env.get("BINTRAY_PASS")
     } yield BintrayCredentials(name, pass)
 
   /** assign credentials or ask for new ones */

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -179,7 +179,9 @@ object BintrayPlugin extends AutoPlugin {
           version.value,
           publishMavenStyle.value,
           sbtPlugin.value,
-          bintrayReleaseOnPublish.value)
+          bintrayReleaseOnPublish.value,
+          sLog.value
+        )
       }
     }
 

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -28,10 +28,10 @@ object BintrayPlugin extends AutoPlugin {
 
   def bintrayCommonSettings: Seq[Setting[_]] = Seq(
     bintrayChangeCredentials := {
-      Bintray.changeCredentials(bintrayCredentialsFile.value)
+      Bintray.changeCredentials(bintrayCredentialsFile.value, streams.value.log)
     },
     bintrayWhoami := {
-      Bintray.whoami(Bintray.ensuredCredentials(bintrayCredentialsFile.value), streams.value.log)
+      Bintray.whoami(Bintray.ensuredCredentials(bintrayCredentialsFile.value, streams.value.log), streams.value.log)
     }
   )
 
@@ -70,7 +70,7 @@ object BintrayPlugin extends AutoPlugin {
     // perhaps we should try overriding something in the publishConfig setting -- https://github.com/sbt/sbt-pgp/blob/master/pgp-plugin/src/main/scala/com/typesafe/sbt/pgp/PgpSettings.scala#L124-L131
     publishTo in bintray := publishToBintray.value,
     resolvers in bintray := {
-      Bintray.buildResolvers(Bintray.ensuredCredentials(bintrayCredentialsFile.value),
+      Bintray.buildResolvers(Bintray.ensuredCredentials(bintrayCredentialsFile.value, sLog.value),
         bintrayOrganization.value,
         bintrayRepository.value)
     },
@@ -83,7 +83,7 @@ object BintrayPlugin extends AutoPlugin {
     },
     bintrayVersionAttributes := {
       val scalaVersions = crossScalaVersions.value
-      val sv = Map(AttrNames.scalas -> scalaVersions.map(Attr.Version(_)))
+      val sv = Map(AttrNames.scalas -> scalaVersions.map(Attr.Version))
       if (sbtPlugin.value) sv ++ Map(AttrNames.sbtVersion-> Seq(Attr.Version(sbtVersion.value)))
       else sv
     },
@@ -95,7 +95,7 @@ object BintrayPlugin extends AutoPlugin {
       Bintray.ensureLicenses(licenses.value, bintrayOmitLicense.value)
     },
     bintrayEnsureCredentials := {
-      Bintray.ensuredCredentials(bintrayCredentialsFile.value).get
+      Bintray.ensuredCredentials(bintrayCredentialsFile.value, streams.value.log).get
     },
     bintrayEnsureBintrayPackageExists := ensurePackageTask.value,
     bintrayUnpublish := {
@@ -174,7 +174,7 @@ object BintrayPlugin extends AutoPlugin {
       val btyOrg = bintrayOrganization.value
       val repoName = bintrayRepository.value
       // ensure that we have credentials to build a resolver that can publish to bintray
-      Bintray.withRepo(credsFile, btyOrg, repoName, prompt = false) { repo =>
+      Bintray.withRepo(credsFile, btyOrg, repoName, sLog.value) { repo =>
         repo.buildPublishResolver(bintrayPackage.value,
           version.value,
           publishMavenStyle.value,
@@ -189,8 +189,8 @@ object BintrayPlugin extends AutoPlugin {
       val credsFile = bintrayCredentialsFile.value
       val btyOrg = bintrayOrganization.value
       val repoName = bintrayRepository.value
-      (Bintray.withRepo(credsFile, btyOrg, repoName) { repo =>
+      Bintray.withRepo(credsFile, btyOrg, repoName, streams.value.log) { repo =>
         repo.packageVersions(bintrayPackage.value, streams.value.log)
-      }).getOrElse(Nil)
+      }.getOrElse(Nil)
     }
 }

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -125,7 +125,7 @@ object BintrayPlugin extends AutoPlugin {
   private def vcsUrlTask: Initialize[Task[Option[String]]] =
     task {
       Bintray.resolveVcsUrl.recover { case _ => None }.get
-    } tag(Git)
+    }.tag(Git)
 
   // uses taskDyn because it can return one of two potential tasks
   // as its result, each with their own dependencies

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -98,12 +98,10 @@ object BintrayPlugin extends AutoPlugin {
       Bintray.ensuredCredentials(bintrayCredentialsFile.value, streams.value.log).get
     },
     bintrayEnsureBintrayPackageExists := ensurePackageTask.value,
-    bintrayUnpublish := {
-      val e1 = bintrayEnsureBintrayPackageExists
-      val e2 = bintrayEnsureLicenses
+    bintrayUnpublish := Def.task {
       val repo = bintrayRepo.value
       repo.unpublish(bintrayPackage.value, version.value, streams.value.log)
-    },
+    }.dependsOn(bintrayEnsureBintrayPackageExists, bintrayEnsureLicenses).value,
     bintrayRemoteSign := {
       val repo = bintrayRepo.value
       repo.remoteSign(bintrayPackage.value, version.value, streams.value.log)

--- a/src/main/scala/BintrayRepo.scala
+++ b/src/main/scala/BintrayRepo.scala
@@ -52,13 +52,13 @@ case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repo
     }
 
   def buildPublishResolver(packageName: String, vers: String, mvnStyle: Boolean,
-    isSbtPlugin: Boolean, isRelease: Boolean): Resolver =
+    isSbtPlugin: Boolean, isRelease: Boolean, log: Logger): Resolver =
     {
       val pkg = repo.get(packageName)
       // warn the user that bintray expects maven published artifacts to be published to the `maven` repo
       // but they have explicitly opted into a publish style and/or repo that
-      // deviates from that expecation
-      if (Bintray.defaultMavenRepository == repo && !mvnStyle) println(
+      // deviates from that expectation
+      if (Bintray.defaultMavenRepository == repo.repo && !mvnStyle) log.info(
         "you have opted to publish to a repository named 'maven' but publishMavenStyle is assigned to false. This may result in unexpected behavior")
       Bintray.publishTo(repo, pkg, vers, mvnStyle, isSbtPlugin, isRelease)
     }


### PR DESCRIPTION
Removes the prompt from `ensuredCredentials` and gives information on how to set the credentials instead. This is because the current version uses `ensuredCredentials` with prompt even when loading the setting, and the whole prompt logic is kind of too messy and there's different ways to set the credentials now.

Also gets rid of most of the printlns by passing loggers around. (addresses #114 #115) 