### PR TITLE
#126 Add file credentials only if the file exists

### DIFF
--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -75,7 +75,7 @@ object BintrayPlugin extends AutoPlugin {
         bintrayRepository.value)
     },
     credentials in bintray := {
-      Credentials(bintrayCredentialsFile.value) :: Nil
+      Seq(bintrayCredentialsFile.value).filter(_.exists).map(Credentials.apply)
     },
     bintrayPackageAttributes := {
       if (sbtPlugin.value) Map(AttrNames.sbtPlugin -> Seq(Attr.Boolean(sbtPlugin.value)))


### PR DESCRIPTION
Otherwise `sbt.Credentials.forHost` fails with FileNotFoundException and other sources for credentials are not checked.

Fixes #126