### PR TITLE
#124 Do not log when missing credentials

### DIFF
--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -57,13 +57,6 @@ object Bintray {
       propsCredentials
         .orElse(envCredentials)
         .orElse(BintrayCredentials.read(credsFile))
-        .orElse {
-          log.warn(s"Missing bintray credentials. " +
-            s"Either create a credentials file with the bintrayChangeCredentials task, " +
-            s"set the BINTRAY_USER and BINTRAY_PASS environment variables or " +
-            s"pass bintray.user and bintray.pass properties to sbt.")
-          None
-        }
 
   private def propsCredentials =
     for {

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -95,7 +95,12 @@ object BintrayPlugin extends AutoPlugin {
       Bintray.ensureLicenses(licenses.value, bintrayOmitLicense.value)
     },
     bintrayEnsureCredentials := {
-      Bintray.ensuredCredentials(bintrayCredentialsFile.value, streams.value.log).get
+      Bintray.ensuredCredentials(bintrayCredentialsFile.value, streams.value.log).getOrElse {
+        sys.error(s"Missing bintray credentials. " +
+          s"Either create a credentials file with the bintrayChangeCredentials task, " +
+          s"set the BINTRAY_USER and BINTRAY_PASS environment variables or " +
+          s"pass bintray.user and bintray.pass properties to sbt.")
+      }
     },
     bintrayEnsureBintrayPackageExists := ensurePackageTask.value,
     bintrayUnpublish := Def.task {


### PR DESCRIPTION
Instead show an error when bintray task is called and no credentials can
be resolved.

Fixes #124 