### PR TITLE
Workaround for publishing SBT plugins using maven style

### DIFF
--- a/src/main/scala/Bintray.scala
+++ b/src/main/scala/Bintray.scala
@@ -12,13 +12,21 @@ object Bintray {
 
   def publishTo(repo: Client#Repo, pkg: Client#Repo#Package, version: String,
     mvnStyle: Boolean = true, isSbtPlugin: Boolean = false, release: Boolean = false): Resolver =
-    if (mvnStyle) RawRepository(
-      BintrayMavenResolver(s"Bintray-Maven-Publish-${repo.subject}-${repo.repo}-${pkg.name}",
-                           s"https://api.bintray.com/maven/${repo.subject}/${repo.repo}/${repo.repo}", pkg, release))
-    else RawRepository(
-      BintrayIvyResolver(s"Bintray-${if (isSbtPlugin) "Sbt" else "Ivy"}-Publish-${repo.subject}-${repo.repo}-${pkg.name}",
-                         pkg.version(version),
-                         sbt.Resolver.ivyStylePatterns.artifactPatterns, release))
+    RawRepository(
+      (mvnStyle, isSbtPlugin) match {
+        case (true, true) =>
+          BintrayMavenSbtPluginResolver(
+            s"Bintray-Sbt-Maven-Publish-${repo.subject}-${repo.repo}-${pkg.name}",
+            pkg.version(version), release)
+        case (true, _) =>
+          BintrayMavenResolver(
+            s"Bintray-Maven-Publish-${repo.subject}-${repo.repo}-${pkg.name}",
+            s"https://api.bintray.com/maven/${repo.subject}/${repo.repo}/${repo.repo}", pkg, release)
+        case (false, _) =>
+          BintrayIvyResolver(
+            s"Bintray-${if (isSbtPlugin) "Sbt" else "Ivy"}-Publish-${repo.subject}-${repo.repo}-${pkg.name}",
+            pkg.version(version), release)
+      })
 
   def whoami(creds: Option[BintrayCredentials], log: Logger): String =
     {


### PR DESCRIPTION
When the artifact is an SBT plugin (`sbtPlugin := true`) and is configured to be published using maven style (`publishMavenStyle := true`) instead of stripping the artifact minor scala version and minor sbt version it uses the content bintray API to push the artifacts.

Bintray does not allow pushing artifacts using the maven upload API as SBT plugin layout is incompatible with the maven one.

The previous behaviour is kept when the project is not an SBT plugin or the setting to publish using the maven style is set to false.

Credit goes to @jvican for his original pull request and trying to push for a proper SBT fix.

Related to #125, sbt/sbt#3410
Fixes #72