### PR TITLE
Be more frugal with HTTP client thread pool

### DIFF
--- a/src/main/scala/BintrayRepo.scala
+++ b/src/main/scala/BintrayRepo.scala
@@ -9,7 +9,7 @@ case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repo
   import scala.concurrent.ExecutionContext.Implicits.global
   import dispatch.as
 
-  val http: Http = new Http()
+  lazy val http: Http = new Http()
   lazy val BintrayCredentials(user, key) = credential
   lazy val client: Client = Client(user, key, http)
   lazy val repo: Client#Repo = client.repo(org.getOrElse(user), repoName)


### PR DESCRIPTION
  - Ensure that we don't needlessly create HTTP clients and leak threads
  - Lazily initialize the HTTP client (and its thread pool)

More details in the commit comments.

Historical context:

Prior to https://github.com/sbt/sbt-bintray/pull/53, the HTTP client
was created and discarded on each operation (which wasn't leaky but
was presumably a drag on performance.) I notice that in that change,
a `close` operation was added to `BintrayRepo` but it isn't actually
called.

Fixes #144 