### PR TITLE
Expose syncing with sonatype staging repo without maven central release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val root = (project in file("."))
       case _             => sys error s"Unhandled sbt version ${sbtCrossVersion.value}"
     }),
     libraryDependencies ++= Seq(
-      "org.foundweekends" %% "bintry" % "0.5.1",
+      "org.foundweekends" %% "bintry" % "0.5.2",
       "org.slf4j" % "slf4j-nop" % "1.7.7"), // https://github.com/sbt/sbt-bintray/issues/26
     resolvers += Resolver.sonatypeRepo("releases"),
     scriptedSettings,

--- a/src/main/scala/BintrayKeys.scala
+++ b/src/main/scala/BintrayKeys.scala
@@ -2,6 +2,8 @@ package bintray
 
 import sbt._
 
+import scala.concurrent.duration.Duration
+
 trait BintrayKeys {
   val bintray = taskKey[String]("sbt-bintray is an interface for the bintray package service")
 
@@ -64,6 +66,9 @@ trait BintrayKeys {
 
   val bintraySyncSonatypeStaging = taskKey[Unit](
     "Sync bintray-published artifacts with sonatype staging repo without releasing them to maven central")
+
+  val bintraySyncMavenCentralRetries = settingKey[Seq[Duration]](
+    "In case of synchronization failure, it will be retried according to delays sepcified. Set to empty sequence for no retries.")
 
   val bintrayVcsUrl = taskKey[Option[String]](
     "Canonical url for hosted version control repository")

--- a/src/main/scala/BintrayKeys.scala
+++ b/src/main/scala/BintrayKeys.scala
@@ -62,6 +62,9 @@ trait BintrayKeys {
   val bintraySyncMavenCentral = taskKey[Unit](
     "Sync bintray-published artifacts with maven central")
 
+  val bintraySyncSonatypeStaging = taskKey[Unit](
+    "Sync bintray-published artifacts with sonatype staging repo without releasing them to maven central")
+
   val bintrayVcsUrl = taskKey[Option[String]](
     "Canonical url for hosted version control repository")
 

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -113,6 +113,7 @@ object BintrayPlugin extends AutoPlugin {
     },
     bintraySyncMavenCentral := syncMavenCentral(close = true).value,
     bintraySyncSonatypeStaging := syncMavenCentral(close = false).value,
+    bintraySyncMavenCentralRetries := Seq.empty,
     bintrayRelease := {
       val _ = publishVersionAttributesTask.value
       val repo = bintrayRepo.value
@@ -127,7 +128,7 @@ object BintrayPlugin extends AutoPlugin {
 
   private def syncMavenCentral(close: Boolean): Initialize[Task[Unit]] = task {
     val repo = bintrayRepo.value
-    repo.syncMavenCentral(bintrayPackage.value, version.value, credentials.value, close, streams.value.log)
+    repo.syncMavenCentral(bintrayPackage.value, version.value, credentials.value, close, bintraySyncMavenCentralRetries.value, streams.value.log)
   }
 
   private def vcsUrlTask: Initialize[Task[Option[String]]] =

--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -111,10 +111,8 @@ object BintrayPlugin extends AutoPlugin {
       val repo = bintrayRepo.value
       repo.remoteSign(bintrayPackage.value, version.value, streams.value.log)
     },
-    bintraySyncMavenCentral := {
-      val repo = bintrayRepo.value
-      repo.syncMavenCentral(bintrayPackage.value, version.value, credentials.value, streams.value.log)
-    },
+    bintraySyncMavenCentral := syncMavenCentral(close = true).value,
+    bintraySyncSonatypeStaging := syncMavenCentral(close = false).value,
     bintrayRelease := {
       val _ = publishVersionAttributesTask.value
       val repo = bintrayRepo.value
@@ -126,6 +124,11 @@ object BintrayPlugin extends AutoPlugin {
     publishTo := (publishTo in bintray).value,
     publish := dynamicallyPublish.value
   )
+
+  private def syncMavenCentral(close: Boolean): Initialize[Task[Unit]] = task {
+    val repo = bintrayRepo.value
+    repo.syncMavenCentral(bintrayPackage.value, version.value, credentials.value, close, streams.value.log)
+  }
 
   private def vcsUrlTask: Initialize[Task[Option[String]]] =
     task {

--- a/src/main/scala/BintrayRepo.scala
+++ b/src/main/scala/BintrayRepo.scala
@@ -131,13 +131,13 @@ case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repo
    *  this requires already having a sonatype oss account set up.
    *  this is itself quite a task but in the case the user has done this in the past
    *  this can be quiet a convenient feature */
-  def syncMavenCentral(packageName: String, vers: String, creds: Seq[Credentials], log: Logger): Unit =
+  def syncMavenCentral(packageName: String, vers: String, creds: Seq[Credentials], close: Boolean, log: Logger): Unit =
     {
       val btyVersion = repo.get(packageName).version(vers)
       val BintrayCredentials(sonauser, sonapass) =
         resolveSonatypeCredentials(creds)
       await.result(
-        btyVersion.mavenCentralSync(sonauser, sonapass)(asStatusAndBody)) match {
+        btyVersion.mavenCentralSync(sonauser, sonapass, close)(asStatusAndBody)) match {
         case (200, body) =>
           // store these sonatype credentials in memory for the remainder of the sbt session
           Cache.putMulti(

--- a/src/main/scala/BintrayRepo.scala
+++ b/src/main/scala/BintrayRepo.scala
@@ -5,6 +5,8 @@ import Bintray._
 import bintry.Client
 import dispatch.Http
 
+import scala.concurrent.duration.Duration
+
 case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repoName: String) extends DispatchHandlers {
   import scala.concurrent.ExecutionContext.Implicits.global
   import dispatch.as
@@ -131,27 +133,28 @@ case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repo
    *  this requires already having a sonatype oss account set up.
    *  this is itself quite a task but in the case the user has done this in the past
    *  this can be quiet a convenient feature */
-  def syncMavenCentral(packageName: String, vers: String, creds: Seq[Credentials], close: Boolean, log: Logger): Unit =
+  def syncMavenCentral(packageName: String, vers: String, creds: Seq[Credentials], close: Boolean, retryDelays: Seq[Duration], log: Logger): Unit =
     {
       val btyVersion = repo.get(packageName).version(vers)
-      val BintrayCredentials(sonauser, sonapass) =
-        resolveSonatypeCredentials(creds)
-      await.result(
-        btyVersion.mavenCentralSync(sonauser, sonapass, close)(asStatusAndBody)) match {
-        case (200, body) =>
-          // store these sonatype credentials in memory for the remainder of the sbt session
-          Cache.putMulti(
-            ("sona.user", sonauser), ("sona.pass", sonapass))
-          log.info(s"$owner/$packageName@$vers was synced with maven central")
-          log.info(body)
-        case (404, body) =>
-          log.info(s"$owner/$packageName@$vers was not found. try publishing this package version to bintray first by typing `publish`")
-          log.info(s"body $body")
-        case (_, body) =>
-          // ensure these items are removed from the cache, they are probably bad
-          Cache.removeMulti("sona.user", "sona.pass")
-          sys.error(s"failed to sync $owner/$packageName@$vers with maven central: $body")
+      val BintrayCredentials(sonauser, sonapass) = resolveSonatypeCredentials(creds)
+      Retry.withDelays(log, retryDelays) {
+        await.result(
+          btyVersion.mavenCentralSync(sonauser, sonapass, close)(asStatusAndBody)) match {
+          case (200, body) =>
+            // store these sonatype credentials in memory for the remainder of the sbt session
+            Cache.putMulti(
+              ("sona.user", sonauser), ("sona.pass", sonapass))
+            log.info(s"$owner/$packageName@$vers was synced with maven central")
+            log.info(body)
+          case (404, body) =>
+            log.info(s"$owner/$packageName@$vers was not found. try publishing this package version to bintray first by typing `publish`")
+            log.info(s"body $body")
+          case (_, body) =>
+            // ensure these items are removed from the cache, they are probably bad
+            Cache.removeMulti("sona.user", "sona.pass")
+            sys.error(s"failed to sync $owner/$packageName@$vers with maven central: $body")
         }
+      }
     }
 
   private def resolveSonatypeCredentials(

--- a/src/main/scala/Retry.scala
+++ b/src/main/scala/Retry.scala
@@ -1,0 +1,22 @@
+package bintray
+
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+import sbt.Logger
+
+object Retry {
+
+  def withDelays[A](log: Logger, delays: Seq[Duration])(action: => A): A = {
+    delays match {
+      case Seq() => action
+      case delay +: rest =>
+        try action catch {
+          case NonFatal(ex) =>
+            log.warn(s"Failed with error: ${ex.getMessage}\nRetrying in $delay...")
+            Thread.sleep(delay.toMillis)
+            withDelays(log, rest)(action)
+        }
+    }
+  }
+
+}


### PR DESCRIPTION
# bintraySyncSonatypeStaging
I added it as a new task. It does the same as bintraySyncMavenCentral, except that it passes `close` flag set to `false`, so that artifacts are placed in sonatype staging repo, but not yet released.

# Bintry version bump
This is required for PR to actually work, because the new version fixes bug with closing. It seems like 0.5.2 didn't get released to maven central, so this PR will have to wait until fixed.

# Retries
Genesis of this change can be found [in this travis build](https://travis-ci.org/quasar-analytics/quasar/jobs/345398918).
Log line 1546 says:
```
[error] java.lang.RuntimeException: failed to sync slamdata-inc/quasar-common-internal@33.0.0 with maven central: {"status":"Validation Failed","messages":"[Missing Signature: '/org/quasar-analytics/quasar-common-internal_2.12/33.0.0/quasar-common-internal_2.12-33.0.0-sources.jar.asc' does not exist for 'quasar-common-internal_2.12-33.0.0-sources.jar'., Dropping existing partial staging repository.]"}
```
So it says, that file is missing, but it shouldn't be, because line 1249 says that it was published:
```
[info] 	published quasar-common-internal_2.12 to https://api.bintray.com/maven/slamdata-inc/maven-public/maven-public/org/quasar-analytics/quasar-common-internal_2.12/33.0.0/quasar-common-internal_2.12-33.0.0-sources.jar.asc
```
This is probably due to replicas are not yet consistent at that point of time. It can be observed that soon after publishing a version, some artifacts are visible, and some are not, or version doesn't exist at all, depending on when you refresh the page.
For this reason, to limit number of failed builds, I implemented retry mechanism. It retries according to `bintraySyncMavenCentralRetries` setting. If the seq is empty, it behaves just like before, and this is the default I set, to not alter behavior.
One can set it for example to:
```
bintraySyncMavenCentralRetries := {
  import scala.concurrent.duration._
  Seq(5.seconds, 1.minute, 5.minutes)
}
```
In case of exception from mavenSync task, (i.e. status other than 200 or 404) it will wait 5s ant try again, if it fails, it will retry after a minute, and finally after 5 minutes. If it still fails after 5, the exception is rethrown. If at any point it succeeds, result is returned as if nothing bad happened.

If this change is too custom or hacky, let me know, I will just remove the commit. It can be implemented in client project of this plugin in a similar way. Although I think it could be helpful if someone faces similar problem.