### PR TITLE
skip in publish support

### DIFF
--- a/src/main/scala/BintrayPlugin.scala
+++ b/src/main/scala/BintrayPlugin.scala
@@ -141,6 +141,17 @@ object BintrayPlugin extends AutoPlugin {
   // see also: http://www.scala-sbt.org/0.13/docs/Tasks.html#Dynamic+Computations+with
   private def dynamicallyPublish: Initialize[Task[Unit]] =
     taskDyn {
+      val sk = ((skip in publish) ?? false).value
+      val s = streams.value
+      val ref = thisProjectRef.value
+      if (sk) Def.task {
+        s.log.debug(s"Skipping publish for ${ref.project}")
+      }
+      else dynamicallyPublish0
+    }
+
+  private def dynamicallyPublish0: Initialize[Task[Unit]] =
+    taskDyn {
       (if (bintrayReleaseOnPublish.value) bintrayRelease else warnToRelease).dependsOn(publishTask(publishConfiguration, deliver))
     } dependsOn(bintrayEnsureBintrayPackageExists, bintrayEnsureLicenses)
 


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/3136
Fixes https://github.com/sbt/sbt-bintray/issues/93

Locally tested that it skips publishing.

```
sbt-assembly> publish
[success] Total time: 0 s, completed Mar 27, 2018 1:14:44 PM
sbt-assembly> debug
[debug] > shell
sbt-assembly> publish
[debug] > publish
[debug] Evaluating tasks: *:publish
[debug] Running task... Cancel: Null, check cycles: false, forcegc: true
[debug] Skipping publish for root
[success] Total time: 0 s, completed Mar 27, 2018 1:14:48 PM
[debug] > shell
```
