### PR TITLE
Skip unpublish on projects marked skip on publish

### DIFF
--- a/src/main/scala/BintrayRepo.scala
+++ b/src/main/scala/BintrayRepo.scala
@@ -80,7 +80,8 @@ case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repo
   /** unpublish (delete) a version of a package */
   def unpublish(packageName: String, vers: String, log: Logger): Unit =
     await.result(repo.get(packageName).version(vers).delete(asStatusAndBody)) match {
-      case (200, _) =>  log.info(s"$owner/$packageName@$vers was discarded")
+      case (200, _) => log.info(s"$owner/$packageName@$vers was discarded")
+      //case (404, _) => log.warn(s"$owner/$packageName@$vers was not found")
       case (_, fail) => sys.error(s"failed to discard $owner/$packageName@$vers: $fail")
     }
 

--- a/src/main/scala/BintrayRepo.scala
+++ b/src/main/scala/BintrayRepo.scala
@@ -81,7 +81,7 @@ case class BintrayRepo(credential: BintrayCredentials, org: Option[String], repo
   def unpublish(packageName: String, vers: String, log: Logger): Unit =
     await.result(repo.get(packageName).version(vers).delete(asStatusAndBody)) match {
       case (200, _) => log.info(s"$owner/$packageName@$vers was discarded")
-      //case (404, _) => log.warn(s"$owner/$packageName@$vers was not found")
+      case (404, _) => log.warn(s"$owner/$packageName@$vers was not found")
       case (_, fail) => sys.error(s"failed to discard $owner/$packageName@$vers: $fail")
     }
 


### PR DESCRIPTION
When a project defines `skip in publish := true` then we should skip it while unpublishing artifacts as well.  Currently, sbt-bintray will throw an error for discard request which return a 404 from bintray.  This occurs when a project that does not exist to be unpublished, as described in #167.

An alternative would be to ignore artifacts that can't be unpublished and raise a warning log message instead of fatal error.