### PR TITLE
Fix homepage url in build settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val unusedWarnings = Seq("-Ywarn-unused-import", "-Ywarn-unused")
 
 lazy val commonSettings: Seq[Setting[_]] = Seq(
     organization in ThisBuild := "org.foundweekends",
-    homepage in ThisBuild := Some(url(s"https://github.com/sbt/${name.value}/#readme")),
+    homepage in ThisBuild := Some(url(s"https://github.com/sbt/${name.value}")),
     licenses in ThisBuild := Seq("MIT" ->
       url(s"https://github.com/sbt/${name.value}/blob/${version.value}/LICENSE")),
     description in ThisBuild := "package publisher for bintray.com",


### PR DESCRIPTION
The `homepage` setting in the build file is incorrect, which seems to be causing Scala Steward to generate invalid links to the project website and most importantly the diff comparison between releases, e.g.

`https://github.com/sbt/sbt-bintray/#readme` and `https://github.com/sbt/sbt-bintray/#readme/compare/v0.5.5...v0.5.6`.

An example PR [here](https://github.com/mwz/sonar-scala/pull/337).

@fthomas I'm not sure why Scala Steward also generates a link to the changelog file which doesn't seem to exist in the project, but that's probably caused by a different issue (except for the incorrect `#readme` part), e.g. `https://github.com/sbt/sbt-bintray/#readme/blob/master/CHANGELOG.md`.