### PR TITLE
Fix homepage setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val unusedWarnings = Seq("-Ywarn-unused-import", "-Ywarn-unused")
 
 ThisBuild / organization := "org.foundweekends"
-ThisBuild / homepage     := Some(url(s"https://github.com/sbt/${name.value}"))
+ThisBuild / homepage     := Some(url("https://github.com/sbt/sbt-bintray"))
 ThisBuild / licenses     := Seq("MIT" ->
   url(s"https://github.com/sbt/${name.value}/blob/${version.value}/LICENSE"))
 ThisBuild / description  := "package publisher for bintray.com"


### PR DESCRIPTION
https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/scala_2.12/sbt_1.0/0.6.1/ivys/ivy.xml contains the following homepage attribute:
```xml
    <description homepage="https://github.com/sbt/root">package publisher for bintray.com</description>
```
This PR changes `https://github.com/sbt/root` (which does not exists) to `https://github.com/sbt/sbt-bintray`.